### PR TITLE
Memory leak fix

### DIFF
--- a/RatingsExporter/Models/NetflixDataTask.swift
+++ b/RatingsExporter/Models/NetflixDataTask.swift
@@ -5,9 +5,9 @@
 //  Created by Jason Beck on 11/27/19.
 //  Copyright © 2019 Jason Beck. All rights reserved.
 //
-import Foundation
+import Foundation.NSURL
 
-protocol NetflixDataTaskProtocol {
+public protocol NetflixDataTaskProtocol {
     var pageRequest: UInt {get set}
     func executeRequestWithURL(url: URL)
 }
@@ -16,9 +16,9 @@ class NetflixDataTask: NetflixDataTaskProtocol {
     var pageRequest: UInt
     private var dataTask: URLSessionDataTask?
     private weak var session: URLSession?
-    private var completion: (NetflixRatingsList?, Error?) -> ()
+    private var completion: (NetflixDataTaskProtocol, NetflixRatingsList?, Error?) -> ()
     
-    init(pageRequest: UInt, usingSession session: URLSession, completion: @escaping (NetflixRatingsList?, Error?) -> ()) {
+    init(pageRequest: UInt, usingSession session: URLSession, completion: @escaping (NetflixDataTaskProtocol, NetflixRatingsList?, Error?) -> ()) {
         self.pageRequest = pageRequest
         self.session = session
         self.completion = completion
@@ -37,7 +37,7 @@ class NetflixDataTask: NetflixDataTaskProtocol {
                 if httpResponse.statusCode != 200 {
                     let userInfo = ["response": response]
                     let error: Error = NSError(domain: "networking.NetflixDataTask", code: httpResponse.statusCode, userInfo: userInfo as [String : Any])
-                    self.completion(nil, error)
+                    self.completion(self, nil, error)
                     return
                 }
                 
@@ -48,15 +48,19 @@ class NetflixDataTask: NetflixDataTaskProtocol {
                     if let json = json, let finalJson = json {
                         guard let ratings = NetflixRatingsList(json: finalJson) else {
                             let error: Error = NSError(domain: "parsing.NetflixDataTask", code: httpResponse.statusCode, userInfo:nil)
-                            self.completion(nil, error)
+                            self.completion(self, nil, error)
                             return
                         }
                         
-                        self.completion(ratings, nil)
+                        self.completion(self, ratings, nil)
                     }
                 }
             }
         })
         self.dataTask = dataTask
+    }
+    
+    deinit {
+        debugLog("Denit called!")
     }
 }

--- a/RatingsExporter/Models/NetflixRatingsManager.swift
+++ b/RatingsExporter/Models/NetflixRatingsManager.swift
@@ -148,6 +148,10 @@ public final class NetflixRatingsManager: NetflixRatingsManagerProtocol {
 		//Fetch the first page
 		self.fetcher.fetchRatings(page: 0)
 	}
+    
+    deinit {
+        debugLog("Deinit called!")
+    }
 }
 
 


### PR DESCRIPTION
NetflixDataTask had a memory leak preventing all active tasks from de-initing.

This has been resolved in this patch. The RatingsFetcher may still have a memory leak. Will investigate later.